### PR TITLE
Allow child interpolations

### DIFF
--- a/src/Leash.js
+++ b/src/Leash.js
@@ -11,6 +11,7 @@ import NodeBuilder from './NodeBuilder'
 
 const START_TABS_REGEX = /^[\t]{1,}/g
 const START_SPACES_REGEX = /^[ ]{1,}/g
+const PLACEHOLDER_ID = '_react_pug_replace'
 
 const ERROR_MSGS = {
   NO_AST_NODES: 'No AST node(s) could be generated from the provided pug template',
@@ -130,8 +131,7 @@ export default class Leash {
   templatePlaceholder (template: Array<BabelNode>) : string {
     return template.map((section, index) => {
       let hasValue = this.interpolations[index] !== undefined
-
-      let placeholder = hasValue ? ('/~' + index + '~/') : ''
+      let placeholder = hasValue ? PLACEHOLDER_ID : ''
 
       return `${section.value.raw}${placeholder}`
     }).join('')

--- a/test/fixtures/nested-interpolation/actual.js
+++ b/test/fixtures/nested-interpolation/actual.js
@@ -1,0 +1,7 @@
+function render() {
+  const SubComponent = pug`div Title`	
+	return pug`
+		.component__class
+      ${ SubComponent }
+	`
+}

--- a/test/fixtures/nested-interpolation/expected.js
+++ b/test/fixtures/nested-interpolation/expected.js
@@ -1,0 +1,8 @@
+"use strict";
+
+function render() {
+	var SubComponent = React.createElement("div", null, "Title");	
+	return React.createElement("div", {
+		className: 'component__class'
+	}, React.createElement(SubComponent, null));
+}


### PR DESCRIPTION
- Alters placeholder value from `/~i~/` to a valid pug element `_react_pug_replace`, allows for nested interpolation such as:

```js
const Div = (props) => {
   return pug`
     div
       ${ props.children }
  `
}
```